### PR TITLE
feat: add GitHub Actions workflow for crate publishing and update package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: publish-crates
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches crate version
+        id: verify
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CLI_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="nblm-cli") | .version')
+          CORE_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="nblm-core") | .version')
+          echo "Tag version: ${TAG_VERSION}"
+          echo "nblm-core version: ${CORE_VERSION}"
+          echo "nblm-cli version: ${CLI_VERSION}"
+          if [ "${TAG_VERSION}" != "${CORE_VERSION}" ] || [ "${TAG_VERSION}" != "${CLI_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) must match crate versions (nblm-core=${CORE_VERSION}, nblm-cli=${CLI_VERSION})"
+            exit 1
+          fi
+
+      - name: Publish nblm-core
+        run: cargo publish -p nblm-core --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Wait for crate index update
+        run: sleep 30
+
+      - name: Publish nblm-cli
+        run: cargo publish -p nblm-cli --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/crates/nblm-cli/Cargo.toml
+++ b/crates/nblm-cli/Cargo.toml
@@ -2,7 +2,14 @@
 name = "nblm-cli"
 version = "0.1.0"
 edition = "2021"
-license = "Apache-2.0"
+license = "MIT"
+description = "Command-line interface for NotebookLM Enterprise API"
+repository = "https://github.com/K-dash/nblm-rs"
+homepage = "https://github.com/K-dash/nblm-rs"
+readme = "../../README.md"
+keywords = ["notebooklm", "cli", "google-cloud", "gemini"]
+categories = ["command-line-utilities"]
+authors = ["K-dash"]
 
 [[bin]]
 name = "nblm"

--- a/crates/nblm-core/Cargo.toml
+++ b/crates/nblm-core/Cargo.toml
@@ -2,7 +2,14 @@
 name = "nblm-core"
 version = "0.1.0"
 edition = "2021"
-license = "Apache-2.0"
+license = "MIT"
+description = "Core library for NotebookLM Enterprise API client"
+repository = "https://github.com/K-dash/nblm-rs"
+homepage = "https://github.com/K-dash/nblm-rs"
+readme = "../../README.md"
+keywords = ["notebooklm", "api", "google-cloud", "gemini"]
+categories = ["api-bindings"]
+authors = ["K-dash"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
* Introduced a new workflow to automate the publishing of nblm-core and nblm-cli crates upon release.
* Updated license to MIT and added metadata (description, repository, homepage, keywords, categories, authors) in Cargo.toml for both nblm-core and nblm-cli.