### PR TITLE
feat: implement file upload functionality for notebook sources

### DIFF
--- a/crates/nblm-cli/Cargo.toml
+++ b/crates/nblm-cli/Cargo.toml
@@ -26,6 +26,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "jso
 nblm-core = { version = "0.1.0", path = "../nblm-core" }
 humantime = "2.3.0"
 url = "2.5.7"
+mime_guess = "2.0.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/crates/nblm-cli/src/util/io.rs
+++ b/crates/nblm-cli/src/util/io.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use nblm_core::models::{
     BatchCreateSourcesResponse, ListRecentlyViewedResponse, Notebook, ShareResponse,
+    UploadSourceFileResponse,
 };
 use serde_json::json;
 
@@ -46,6 +47,31 @@ pub fn emit_sources(
         "error_count": response.error_count,
     });
     emit_json(payload, json_mode);
+    Ok(())
+}
+
+pub fn emit_uploaded_source(
+    notebook_id: &str,
+    file_name: &str,
+    content_type: &str,
+    response: &UploadSourceFileResponse,
+    json_mode: bool,
+) -> Result<()> {
+    let payload = json!({
+        "notebook_id": notebook_id,
+        "file_name": file_name,
+        "content_type": content_type,
+        "source_id": response.source_id,
+        "extra": response.extra,
+    });
+    emit_json(payload, json_mode);
+    if !json_mode {
+        if let Some(source_id) = response.source_id.as_ref().and_then(|id| id.id.as_deref()) {
+            println!("Created source: {source_id}");
+        } else {
+            println!("Upload request accepted (source ID unavailable)");
+        }
+    }
     Ok(())
 }
 

--- a/crates/nblm-cli/tests/_helpers/mock.rs
+++ b/crates/nblm-cli/tests/_helpers/mock.rs
@@ -117,6 +117,38 @@ impl MockApi {
             .await;
     }
 
+    pub async fn stub_sources_upload_file(
+        &self,
+        project: &str,
+        location: &str,
+        notebook_id: &str,
+        source_id: &str,
+    ) {
+        let path_str = format!(
+            "/upload/v1alpha/projects/{}/locations/{}/notebooks/{}/sources:uploadFile",
+            project, location, notebook_id
+        );
+        let response = json!({
+            "sourceId": {
+                "id": format!(
+                    "projects/{}/locations/{}/notebooks/{}/sources/{}",
+                    project, location, notebook_id, source_id
+                )
+            }
+        });
+
+        Mock::given(method("POST"))
+            .and(path(path_str))
+            .and(query_param("uploadType", "media"))
+            .and(header("authorization", "Bearer DUMMY_TOKEN"))
+            .and(header("x-goog-upload-protocol", "raw"))
+            .and(header_exists("content-type"))
+            .and(header_exists("x-goog-upload-file-name"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .mount(&self.server)
+            .await;
+    }
+
     /// Stub for POST /v1alpha/projects/{project}/locations/{location}/notebooks/{notebook_id}:share
     pub async fn stub_notebook_share(&self, project: &str, location: &str, notebook_id: &str) {
         let path_str = format!(

--- a/crates/nblm-cli/tests/sources_upload.rs
+++ b/crates/nblm-cli/tests/sources_upload.rs
@@ -1,0 +1,48 @@
+mod _helpers;
+
+use std::io::Write;
+
+use _helpers::{cmd::CommonArgs, mock::MockApi};
+use predicates::prelude::*;
+use serial_test::serial;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+#[serial]
+async fn sources_upload_file() {
+    let mock = MockApi::start().await;
+    let args = CommonArgs::default();
+    let notebook_id = "notebook-upload";
+
+    mock.stub_sources_upload_file(
+        &args.project_number,
+        &args.location,
+        notebook_id,
+        "source-upload",
+    )
+    .await;
+
+    let mut temp_file = NamedTempFile::new().expect("temp file");
+    writeln!(temp_file, "hello world").expect("write temp file");
+    let file_path = temp_file.into_temp_path();
+    let file_str = file_path.to_str().expect("path to str").to_string();
+
+    let mut cmd = _helpers::cmd::nblm();
+    args.with_base_url(&mut cmd, &mock.base_url());
+    cmd.args([
+        "sources",
+        "upload",
+        "--notebook-id",
+        notebook_id,
+        "--file",
+        &file_str,
+        "--content-type",
+        "text/plain",
+        "--display-name",
+        "Sample.txt",
+    ]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Created source:"));
+}

--- a/crates/nblm-core/Cargo.toml
+++ b/crates/nblm-core/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.7"
 backon = "1.6.0"
 tracing = "0.1.41"
 httpdate = "1.0.3"
+bytes = "1.7.1"
 
 [features]
 default = []

--- a/crates/nblm-core/src/models/mod.rs
+++ b/crates/nblm-core/src/models/mod.rs
@@ -14,4 +14,5 @@ pub use requests::{
 };
 pub use responses::{
     AudioOverviewResponse, BatchCreateSourcesResponse, ListRecentlyViewedResponse, ShareResponse,
+    UploadSourceFileResponse,
 };

--- a/crates/nblm-python/Cargo.toml
+++ b/crates/nblm-python/Cargo.toml
@@ -20,3 +20,4 @@ nblm-core = { path = "../nblm-core" }
 pyo3 = { version = "0.23", features = ["extension-module", "abi3-py312"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0"
+mime_guess = "2.0.5"

--- a/crates/nblm-python/src/lib.rs
+++ b/crates/nblm-python/src/lib.rs
@@ -15,7 +15,7 @@ pub use models::{
     BatchCreateSourcesResponse, BatchDeleteNotebooksResponse, BatchDeleteSourcesResponse,
     ListRecentlyViewedResponse, Notebook, NotebookMetadata, NotebookSource, NotebookSourceId,
     NotebookSourceMetadata, NotebookSourceSettings, NotebookSourceYoutubeMetadata, TextSource,
-    VideoSource, WebSource,
+    UploadSourceFileResponse, VideoSource, WebSource,
 };
 
 /// NotebookLM Enterprise API client for Python
@@ -34,6 +34,7 @@ fn nblm(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<WebSource>()?;
     m.add_class::<TextSource>()?;
     m.add_class::<VideoSource>()?;
+    m.add_class::<UploadSourceFileResponse>()?;
     m.add_class::<BatchCreateSourcesResponse>()?;
     m.add_class::<BatchDeleteSourcesResponse>()?;
     m.add_class::<ListRecentlyViewedResponse>()?;

--- a/crates/nblm-python/src/models/responses.rs
+++ b/crates/nblm-python/src/models/responses.rs
@@ -3,7 +3,7 @@ use pyo3::types::{PyDict, PyList};
 
 use crate::error::PyResult;
 
-use super::{extra_to_pydict, Notebook, NotebookSource};
+use super::{extra_to_pydict, Notebook, NotebookSource, NotebookSourceId};
 
 #[pyclass(module = "nblm")]
 pub struct ListRecentlyViewedResponse {
@@ -149,6 +149,46 @@ impl BatchDeleteSourcesResponse {
         response: nblm_core::models::BatchDeleteSourcesResponse,
     ) -> PyResult<Self> {
         Ok(Self {
+            extra: extra_to_pydict(py, &response.extra)?,
+        })
+    }
+}
+
+#[pyclass(module = "nblm")]
+pub struct UploadSourceFileResponse {
+    #[pyo3(get)]
+    pub source_id: Option<Py<NotebookSourceId>>,
+    #[pyo3(get)]
+    pub extra: Py<PyDict>,
+}
+
+#[pymethods]
+impl UploadSourceFileResponse {
+    pub fn __repr__(&self, py: Python) -> String {
+        let has_id = self.source_id.is_some();
+        let extra_keys = self.extra.bind(py).len();
+        format!(
+            "UploadSourceFileResponse(source_id={}, extra_keys={})",
+            has_id, extra_keys
+        )
+    }
+
+    pub fn __str__(&self, py: Python) -> String {
+        self.__repr__(py)
+    }
+}
+
+impl UploadSourceFileResponse {
+    pub fn from_core(
+        py: Python,
+        response: nblm_core::models::UploadSourceFileResponse,
+    ) -> PyResult<Self> {
+        let source_id = match response.source_id {
+            Some(id) => Some(Py::new(py, NotebookSourceId::from_core(py, id)?)?),
+            None => None,
+        };
+        Ok(Self {
+            source_id,
             extra: extra_to_pydict(py, &response.extra)?,
         })
     }

--- a/docs/guides/notebook_sources.md
+++ b/docs/guides/notebook_sources.md
@@ -45,6 +45,46 @@ At least one source type must be provided.
 
 `BatchCreateSourcesResponse.error_count` reflects the number of ingestion failures reported by the API.
 
+## Uploading Files
+
+You can upload local files to a notebook via the CLI or Python bindings. The API currently returns the created `sourceId` and any additional metadata provided by NotebookLM.
+
+### CLI example
+
+```bash
+nblm sources upload \
+  --notebook-id abc123 \
+  --file ./docs/brief.pdf \
+  --content-type application/pdf
+```
+
+The command prints the notebook ID, file metadata, and the returned source ID. When `--content-type` is omitted, the CLI guesses it from the file extension and falls back to `application/octet-stream`.
+
+> [!NOTE]
+> As of 2025-10-25 the NotebookLM API rejects custom display names for uploads (returns HTTP 400). The CLI keeps `--display-name` for forward compatibility but currently ignores it.
+
+### Python example
+
+```python
+from pathlib import Path
+
+from nblm import GcloudTokenProvider, NblmClient
+
+provider = GcloudTokenProvider()
+client = NblmClient(token_provider=provider, project_number="123456789012")
+
+result = client.upload_source_file(
+    notebook_id="abc123",
+    path=Path("./docs/brief.pdf"),
+    content_type="application/pdf",  # optional
+    display_name="Product Brief",    # optional
+)
+
+print(result.source_id.id if result.source_id else "<missing>")
+```
+
+Empty files are rejected client-side. If the API fails to ingest the file, an `nblm.NblmError` is raised with the server-provided message.
+
 ## Deleting Sources
 
 Use `NblmClient.delete_sources()` to remove previously added sources by their full resource names.

--- a/python/src/nblm/__init__.py
+++ b/python/src/nblm/__init__.py
@@ -25,6 +25,7 @@ from .nblm import (
     NotebookSourceSettings,
     NotebookSourceYoutubeMetadata,
     TextSource,
+    UploadSourceFileResponse,
     VideoSource,
     WebSource,
 )
@@ -50,6 +51,7 @@ __all__ = [
     "NotebookSourceSettings",
     "NotebookSourceYoutubeMetadata",
     "TextSource",
+    "UploadSourceFileResponse",
     "VideoSource",
     "WebSource",
 ]

--- a/python/src/nblm/__init__.pyi
+++ b/python/src/nblm/__init__.pyi
@@ -21,6 +21,7 @@ from ._models import (
     NotebookSourceSettings,
     NotebookSourceYoutubeMetadata,
     TextSource,
+    UploadSourceFileResponse,
     VideoSource,
     WebSource,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "NotebookSourceSettings",
     "NotebookSourceYoutubeMetadata",
     "TextSource",
+    "UploadSourceFileResponse",
     "VideoSource",
     "WebSource",
 ]

--- a/python/src/nblm/_client.pyi
+++ b/python/src/nblm/_client.pyi
@@ -1,5 +1,7 @@
 """NblmClient for NotebookLM API operations"""
 
+import os
+
 from ._auth import TokenProvider
 from ._models import (
     BatchCreateSourcesResponse,
@@ -8,6 +10,7 @@ from ._models import (
     ListRecentlyViewedResponse,
     Notebook,
     TextSource,
+    UploadSourceFileResponse,
     VideoSource,
     WebSource,
 )
@@ -100,6 +103,31 @@ class NblmClient:
 
         Returns:
             BatchCreateSourcesResponse: Results for each processed source
+
+        Raises:
+            NblmError: If validation fails or the API request fails
+        """
+
+    def upload_source_file(
+        self,
+        notebook_id: str,
+        path: str | os.PathLike[str],
+        *,
+        content_type: str | None = ...,
+        display_name: str | None = ...,
+    ) -> UploadSourceFileResponse:
+        """
+        Upload a local file as a notebook source.
+
+        Args:
+            notebook_id: Notebook identifier (resource ID, e.g. "abc123")
+            path: Path to the file to upload
+            content_type: Optional HTTP Content-Type header value
+            display_name: Optional display name to attach to the source
+                (NotebookLM currently rejects custom names; kept for future use)
+
+        Returns:
+            UploadSourceFileResponse: Response containing the created source ID
 
         Raises:
             NblmError: If validation fails or the API request fails

--- a/python/src/nblm/_models.pyi
+++ b/python/src/nblm/_models.pyi
@@ -54,6 +54,12 @@ class BatchDeleteSourcesResponse:
 
     extra: dict[str, Any]
 
+class UploadSourceFileResponse:
+    """Response from uploading a file source to a notebook."""
+
+    source_id: NotebookSourceId | None
+    extra: dict[str, Any]
+
 """Data models for nblm"""
 
 class NotebookSourceYoutubeMetadata:

--- a/python/tests/test_sources.py
+++ b/python/tests/test_sources.py
@@ -8,6 +8,7 @@ def test_sources_response_types_available() -> None:
 
     assert nblm.BatchCreateSourcesResponse is not None
     assert nblm.BatchDeleteSourcesResponse is not None
+    assert nblm.UploadSourceFileResponse is not None
     assert nblm.WebSource is not None
     assert nblm.TextSource is not None
     assert nblm.VideoSource is not None
@@ -18,3 +19,4 @@ def test_client_sources_methods_exist() -> None:
 
     assert hasattr(nblm.NblmClient, "add_sources")
     assert hasattr(nblm.NblmClient, "delete_sources")
+    assert hasattr(nblm.NblmClient, "upload_source_file")


### PR DESCRIPTION
- Added a new command to the CLI for uploading local files as sources to notebooks.
- Introduced the UploadArgs struct to handle upload parameters, including notebook ID, file path, content type, and display name.
- Implemented the upload_source_file method in the NblmClient to manage file uploads and handle responses.
- Enhanced Python bindings to support file uploads with appropriate error handling and response management.
- Updated documentation to include usage examples for the new upload feature.
- Added unit tests to validate the upload functionality and ensure reliability.