### PR TITLE
Refactor CLI commands in documentation to remove gcloud authentication references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,41 @@
 
 ## Motivation
 
-Why use this CLI instead of direct API calls or web UI?
+In September 2025, Google released the [NotebookLM Enterprise API](https://cloud.google.com/gemini/enterprise/notebooklm-enterprise/docs/overview), enabling programmatic access to NotebookLM features for the first time.
 
-- **Credential caching**: Leverages gcloud authentication cache - no need to specify API keys or tokens repeatedly
-- **Type safety**: Rust's type system catches errors at compile time, preventing runtime failures
-- **Batch operations**: Add multiple sources to a notebook in a single command
-- **Better error handling**: Clear, actionable error messages with helpful guidance
-- **Automatic retries**: Built-in retry logic with exponential backoff for transient failures
-- **JSON output**: Machine-readable format for automation and scripting workflows
-- **Cross-platform**: Single binary works on Linux and macOS
-- **Developer-friendly**: Command-line interface integrates seamlessly with shell scripts and CI/CD pipelines
+While you can interact with the API using simple `curl` commands, this approach has several limitations that this project addresses:
 
-> [!NOTE]
-> Windows is not supported.
+### Challenges with Direct API Calls
+
+- **Authentication complexity**
+  - **Problem**: Managing OAuth tokens, handling token refresh, and ensuring secure credential storage
+  - **Solution**: Seamless `gcloud` CLI integration with automatic token caching and refresh
+
+- **Manual request construction**
+  - **Problem**: Writing JSON payloads by hand, managing resource names, and handling API versioning
+  - **Solution**: Type-safe CLI flags and Python SDK with intelligent defaults and validation
+
+- **Error handling**
+  - **Problem**: Cryptic HTTP error codes without context or recovery suggestions
+  - **Solution**: Clear, actionable error messages with automatic retries for transient failures
+
+- **Batch operations**
+  - **Problem**: Writing loops to process multiple items, managing API call sequences
+  - **Solution**: Built-in batch commands with simplified syntax for multiple operations
+
+- **Output parsing**
+  - **Problem**: Manual JSON parsing and extracting specific fields from responses
+  - **Solution**: Structured output formats and JSON mode for easy integration with `jq` and other tools
+
+### Project Goals
+
+This project provides production-ready tools that make the NotebookLM API accessible and reliable:
+
+- **Rust CLI**: Fast, cross-platform binary for shell scripting and automation
+- **Python SDK**: Idiomatic Python bindings for application integration
+- **Type safety**: Compile-time checks prevent common API usage errors
+- **Developer experience**: Intuitive commands and clear documentation
+
 
 ## Features (Verified as of 2025-10-25)
 
@@ -115,10 +137,10 @@ export NBLM_LOCATION="global"
 export NBLM_ENDPOINT_LOCATION="global"
 
 # 3. Create a notebook
-nblm --auth gcloud notebooks create --title "My Notebook"
+nblm notebooks create --title "My Notebook"
 
 # 4. Add a source
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id YOUR_NOTEBOOK_ID \
   --web-url "https://example.com" \
   --web-name "Example"
@@ -127,23 +149,32 @@ nblm --auth gcloud sources add \
 ### Python
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 # Initialize client
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create a notebook
-notebook = client.create_notebook("My Notebook")
+notebook = client.create_notebook(title="My Notebook")
 
 # Add sources
-client.add_sources(
+response = client.add_sources(
     notebook_id=notebook.notebook_id,
-    web_sources=[{"url": "https://example.com", "name": "Example"}]
+    web_sources=[WebSource(url="https://example.com", name="Example")]
 )
 ```
+
+## Platform Support
+
+| Platform | CLI | Python SDK |
+|----------|-----|------------|
+| Linux    | [![Linux CLI supported](https://img.shields.io/badge/support-%E2%9C%85-green)](https://shields.io) | [![Linux Python SDK supported](https://img.shields.io/badge/support-%E2%9C%85-green)](https://shields.io) |
+| macOS    | [![macOS CLI supported](https://img.shields.io/badge/support-%E2%9C%85-green)](https://shields.io) | [![macOS Python SDK supported](https://img.shields.io/badge/support-%E2%9C%85-green)](https://shields.io) |
+| Windows  | [![Windows CLI not supported](https://img.shields.io/badge/support-%E2%9D%8C-red)](https://shields.io) | [![Windows Python SDK not supported](https://img.shields.io/badge/support-%E2%9D%8C-red)](https://shields.io) |
+
 
 ## Documentation
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -41,7 +41,7 @@ Two authentication methods are supported:
 
 ```bash
 gcloud auth login
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 ```
 
 ### Environment Variable
@@ -63,7 +63,7 @@ export NBLM_LOCATION="global"
 export NBLM_ENDPOINT_LOCATION="global"
 
 # Now you can omit these flags
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 ```
 
 ## Output Formats
@@ -71,7 +71,7 @@ nblm --auth gcloud notebooks recent
 ### Human-Readable (Default)
 
 ```bash
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 ```
 
 Output:
@@ -85,7 +85,7 @@ Updated: 2025-10-25T10:30:00Z
 ### JSON Format
 
 ```bash
-nblm --auth gcloud --json notebooks recent
+nblm --json notebooks recent
 ```
 
 Output:
@@ -106,9 +106,8 @@ The `--json` flag can be placed anywhere in the command:
 
 ```bash
 # All equivalent
-nblm --json --auth gcloud notebooks recent
-nblm --auth gcloud --json notebooks recent
-nblm --auth gcloud notebooks recent --json
+nblm --json notebooks recent
+nblm notebooks recent --json
 ```
 
 ## Error Handling
@@ -168,13 +167,13 @@ export NBLM_PROJECT_NUMBER="123456789012"
 gcloud auth login
 
 # Create notebook
-nblm --auth gcloud notebooks create --title "My Notebook"
+nblm notebooks create --title "My Notebook"
 
 # List notebooks
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 
 # Add source
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --web-url "https://example.com"
 ```
@@ -183,13 +182,13 @@ nblm --auth gcloud sources add \
 
 ```bash
 # Get all notebook titles
-nblm --auth gcloud --json notebooks recent | jq '.notebooks[].title'
+nblm --json notebooks recent | jq '.notebooks[].title'
 
 # Get first notebook ID
-nblm --auth gcloud --json notebooks recent | jq -r '.notebooks[0].notebookId'
+nblm --json notebooks recent | jq -r '.notebooks[0].notebookId'
 
 # Count notebooks
-nblm --auth gcloud --json notebooks recent | jq '.notebooks | length'
+nblm --json notebooks recent | jq '.notebooks | length'
 ```
 
 ## Next Steps

--- a/docs/cli/audio.md
+++ b/docs/cli/audio.md
@@ -30,13 +30,13 @@ nblm audio create --notebook-id <ID>
 **Create audio overview:**
 
 ```bash
-nblm --auth gcloud audio create --notebook-id abc123
+nblm audio create --notebook-id abc123
 ```
 
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json audio create --notebook-id abc123
+nblm --json audio create --notebook-id abc123
 ```
 
 Output:
@@ -88,13 +88,13 @@ nblm audio delete --notebook-id <ID>
 **Delete audio overview:**
 
 ```bash
-nblm --auth gcloud audio delete --notebook-id abc123
+nblm audio delete --notebook-id abc123
 ```
 
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json audio delete --notebook-id abc123
+nblm --json audio delete --notebook-id abc123
 ```
 
 Output:
@@ -115,7 +115,7 @@ Output:
 
 ```bash
 # Create audio overview
-nblm --auth gcloud audio create --notebook-id abc123
+nblm audio create --notebook-id abc123
 
 echo "Audio overview created. Check status in NotebookLM web UI."
 echo "Generation typically takes 3-5 minutes."
@@ -130,14 +130,14 @@ NOTEBOOK_ID="abc123"
 
 # Delete existing audio overview
 echo "Deleting existing audio overview..."
-nblm --auth gcloud audio delete --notebook-id "$NOTEBOOK_ID"
+nblm audio delete --notebook-id "$NOTEBOOK_ID"
 
 # Wait a moment
 sleep 2
 
 # Create new audio overview
 echo "Creating new audio overview..."
-nblm --auth gcloud audio create --notebook-id "$NOTEBOOK_ID"
+nblm audio create --notebook-id "$NOTEBOOK_ID"
 
 echo "Done. Check NotebookLM web UI for generation status."
 ```
@@ -150,7 +150,7 @@ NOTEBOOKS=("abc123" "def456" "ghi789")
 
 for notebook_id in "${NOTEBOOKS[@]}"; do
   echo "Creating audio overview for notebook: $notebook_id"
-  nblm --auth gcloud audio create --notebook-id "$notebook_id"
+  nblm audio create --notebook-id "$notebook_id"
 done
 
 echo "All audio overviews created. Check web UI for completion status."

--- a/docs/cli/notebooks.md
+++ b/docs/cli/notebooks.md
@@ -31,13 +31,13 @@ nblm notebooks create --title <TITLE>
 **Basic usage:**
 
 ```bash
-nblm --auth gcloud notebooks create --title "My Research Notebook"
+nblm notebooks create --title "My Research Notebook"
 ```
 
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json notebooks create --title "Project Documentation"
+nblm --json notebooks create --title "Project Documentation"
 ```
 
 Output:
@@ -79,19 +79,19 @@ nblm notebooks recent [--page-size <SIZE>]
 **List all recent notebooks:**
 
 ```bash
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 ```
 
 **Limit results:**
 
 ```bash
-nblm --auth gcloud notebooks recent --page-size 10
+nblm notebooks recent --page-size 10
 ```
 
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json notebooks recent
+nblm --json notebooks recent
 ```
 
 Output:
@@ -121,13 +121,13 @@ Output:
 
 ```bash
 # Get all notebook titles
-nblm --auth gcloud --json notebooks recent | jq '.notebooks[].title'
+nblm --json notebooks recent | jq '.notebooks[].title'
 
 # Get all notebook IDs
-nblm --auth gcloud --json notebooks recent | jq '.notebooks[].notebookId'
+nblm --json notebooks recent | jq '.notebooks[].notebookId'
 
 # Get the most recently updated notebook
-nblm --auth gcloud --json notebooks recent | jq '.notebooks[0]'
+nblm --json notebooks recent | jq '.notebooks[0]'
 ```
 
 ### Notes
@@ -157,14 +157,14 @@ nblm notebooks delete --notebook-name <NAME> [--notebook-name <NAME>...]
 **Delete a single notebook:**
 
 ```bash
-nblm --auth gcloud notebooks delete \
+nblm notebooks delete \
   --notebook-name "projects/123456789012/locations/global/notebooks/abc123"
 ```
 
 **Delete multiple notebooks:**
 
 ```bash
-nblm --auth gcloud notebooks delete \
+nblm notebooks delete \
   --notebook-name "projects/123456789012/locations/global/notebooks/abc123" \
   --notebook-name "projects/123456789012/locations/global/notebooks/def456"
 ```
@@ -173,10 +173,10 @@ nblm --auth gcloud notebooks delete \
 
 ```bash
 # Get the full notebook name
-NOTEBOOK_NAME=$(nblm --auth gcloud --json notebooks recent | jq -r '.notebooks[0].name')
+NOTEBOOK_NAME=$(nblm --json notebooks recent | jq -r '.notebooks[0].name')
 
 # Delete it
-nblm --auth gcloud notebooks delete --notebook-name "$NOTEBOOK_NAME"
+nblm notebooks delete --notebook-name "$NOTEBOOK_NAME"
 ```
 
 ### Notes
@@ -192,35 +192,35 @@ nblm --auth gcloud notebooks delete --notebook-name "$NOTEBOOK_NAME"
 
 ```bash
 # Create notebook and extract ID
-NOTEBOOK_ID=$(nblm --auth gcloud --json notebooks create --title "My Notebook" | jq -r '.notebookId')
+NOTEBOOK_ID=$(nblm --json notebooks create --title "My Notebook" | jq -r '.notebookId')
 
 echo "Created notebook: $NOTEBOOK_ID"
 
 # Use the ID in subsequent commands
-nblm --auth gcloud sources add --notebook-id "$NOTEBOOK_ID" --web-url "https://example.com"
+nblm sources add --notebook-id "$NOTEBOOK_ID" --web-url "https://example.com"
 ```
 
 ### List and filter notebooks
 
 ```bash
 # Find notebooks by title
-nblm --auth gcloud --json notebooks recent | jq '.notebooks[] | select(.title | contains("Research"))'
+nblm --json notebooks recent | jq '.notebooks[] | select(.title | contains("Research"))'
 
 # Count notebooks
-nblm --auth gcloud --json notebooks recent | jq '.notebooks | length'
+nblm --json notebooks recent | jq '.notebooks | length'
 
 # Get notebooks created today
 TODAY=$(date +%Y-%m-%d)
-nblm --auth gcloud --json notebooks recent | jq ".notebooks[] | select(.createTime | startswith(\"$TODAY\"))"
+nblm --json notebooks recent | jq ".notebooks[] | select(.createTime | startswith(\"$TODAY\"))"
 ```
 
 ### Delete all notebooks (dangerous)
 
 ```bash
 # WARNING: This deletes ALL notebooks!
-nblm --auth gcloud --json notebooks recent | \
+nblm --json notebooks recent | \
   jq -r '.notebooks[].name' | \
-  xargs -I {} nblm --auth gcloud notebooks delete --notebook-name {}
+  xargs -I {} nblm notebooks delete --notebook-name {}
 ```
 
 ## Error Handling

--- a/docs/cli/sources.md
+++ b/docs/cli/sources.md
@@ -42,7 +42,7 @@ nblm sources add --notebook-id <ID> [SOURCE_OPTIONS...]
 **Add a web URL:**
 
 ```bash
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --web-url "https://example.com" \
   --web-name "Example Website"
@@ -51,7 +51,7 @@ nblm --auth gcloud sources add \
 **Add text content:**
 
 ```bash
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --text "My research notes" \
   --text-name "Notes"
@@ -60,7 +60,7 @@ nblm --auth gcloud sources add \
 **Add YouTube video:**
 
 ```bash
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --video-url "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 ```
@@ -68,7 +68,7 @@ nblm --auth gcloud sources add \
 **Add multiple sources at once:**
 
 ```bash
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --web-url "https://docs.python.org" \
   --web-name "Python Docs" \
@@ -81,7 +81,7 @@ nblm --auth gcloud sources add \
 
 ```bash
 # WARNING: This returns HTTP 500 as of 2025-10-25
-nblm --auth gcloud sources add \
+nblm sources add \
   --notebook-id abc123 \
   --drive-id "FILE_ID" \
   --drive-resource-key "RESOURCE_KEY" \
@@ -91,7 +91,7 @@ nblm --auth gcloud sources add \
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json sources add \
+nblm --json sources add \
   --notebook-id abc123 \
   --web-url "https://example.com"
 ```
@@ -142,7 +142,7 @@ nblm sources upload --notebook-id <ID> --file <PATH> [OPTIONS]
 **Upload a PDF:**
 
 ```bash
-nblm --auth gcloud sources upload \
+nblm sources upload \
   --notebook-id abc123 \
   --file document.pdf
 ```
@@ -150,7 +150,7 @@ nblm --auth gcloud sources upload \
 **Upload with custom content type:**
 
 ```bash
-nblm --auth gcloud sources upload \
+nblm sources upload \
   --notebook-id abc123 \
   --file report.txt \
   --content-type "text/plain"
@@ -159,7 +159,7 @@ nblm --auth gcloud sources upload \
 **Upload with display name:**
 
 ```bash
-nblm --auth gcloud sources upload \
+nblm sources upload \
   --notebook-id abc123 \
   --file research.pdf \
   --display-name "Research Paper 2025"
@@ -168,7 +168,7 @@ nblm --auth gcloud sources upload \
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json sources upload \
+nblm --json sources upload \
   --notebook-id abc123 \
   --file document.pdf
 ```
@@ -211,7 +211,7 @@ nblm sources get --notebook-id <ID> --source-id <SOURCE_ID>
 **Get source details:**
 
 ```bash
-nblm --auth gcloud sources get \
+nblm sources get \
   --notebook-id abc123 \
   --source-id source-1
 ```
@@ -219,7 +219,7 @@ nblm --auth gcloud sources get \
 **JSON output:**
 
 ```bash
-nblm --auth gcloud --json sources get \
+nblm --json sources get \
   --notebook-id abc123 \
   --source-id source-1
 ```
@@ -268,7 +268,7 @@ nblm sources delete --notebook-id <ID> --source-name <NAME> [--source-name <NAME
 **Delete a single source:**
 
 ```bash
-nblm --auth gcloud sources delete \
+nblm sources delete \
   --notebook-id abc123 \
   --source-name "projects/123456789012/locations/global/notebooks/abc123/sources/source-1"
 ```
@@ -276,7 +276,7 @@ nblm --auth gcloud sources delete \
 **Delete multiple sources:**
 
 ```bash
-nblm --auth gcloud sources delete \
+nblm sources delete \
   --notebook-id abc123 \
   --source-name "projects/.../notebooks/abc123/sources/source-1" \
   --source-name "projects/.../notebooks/abc123/sources/source-2"
@@ -288,7 +288,7 @@ nblm --auth gcloud sources delete \
 # List sources and extract names (requires getting notebook details first)
 SOURCE_NAME="projects/123456789012/locations/global/notebooks/abc123/sources/source-1"
 
-nblm --auth gcloud sources delete \
+nblm sources delete \
   --notebook-id abc123 \
   --source-name "$SOURCE_NAME"
 ```
@@ -305,7 +305,7 @@ nblm --auth gcloud sources delete \
 
 ```bash
 # Add source
-RESULT=$(nblm --auth gcloud --json sources add \
+RESULT=$(nblm --json sources add \
   --notebook-id abc123 \
   --web-url "https://example.com")
 
@@ -316,7 +316,7 @@ SOURCE_NAME=$(echo "$RESULT" | jq -r '.sources[0].name')
 SOURCE_ID=$(echo "$SOURCE_NAME" | awk -F'/' '{print $NF}')
 
 # Get source details
-nblm --auth gcloud sources get \
+nblm sources get \
   --notebook-id abc123 \
   --source-id "$SOURCE_ID"
 ```
@@ -327,7 +327,7 @@ nblm --auth gcloud sources get \
 # Upload all PDFs in a directory
 for file in *.pdf; do
   echo "Uploading $file..."
-  nblm --auth gcloud sources upload \
+  nblm sources upload \
     --notebook-id abc123 \
     --file "$file"
 done
@@ -339,7 +339,7 @@ done
 # urls.txt contains one URL per line
 while IFS= read -r url; do
   echo "Adding $url..."
-  nblm --auth gcloud sources add \
+  nblm sources add \
     --notebook-id abc123 \
     --web-url "$url"
 done < urls.txt

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -32,8 +32,7 @@ gcloud config set project YOUR_PROJECT_ID
 
 ```bash
 # Using gcloud authentication (default)
-nblm --auth gcloud \
-  --project-number PROJECT_NUMBER \
+nblm --project-number PROJECT_NUMBER \
   --location global \
   --endpoint-location global \
   notebooks recent

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -67,10 +67,10 @@ os.environ["NBLM_ENDPOINT_LOCATION"] = "global"
 Or pass directly to the client:
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012",
     location="global",
     endpoint_location="global"
@@ -90,11 +90,11 @@ You can create a configuration wrapper:
 ```python
 # config.py
 import os
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 def create_client():
     return NblmClient(
-        token_provider=GCloudTokenProvider(),
+        token_provider=GcloudTokenProvider(),
         project_number=os.getenv("NBLM_PROJECT_NUMBER", "123456789012"),
         location=os.getenv("NBLM_LOCATION", "global"),
         endpoint_location=os.getenv("NBLM_ENDPOINT_LOCATION", "global"),
@@ -107,7 +107,7 @@ Then use it in your code:
 from config import create_client
 
 client = create_client()
-notebook = client.create_notebook("My Notebook")
+notebook = client.create_notebook(title="My Notebook")
 ```
 
 ## Verification
@@ -116,16 +116,16 @@ notebook = client.create_notebook("My Notebook")
 
 ```bash
 # Should work without additional flags if environment variables are set
-nblm --auth gcloud notebooks recent
+nblm notebooks recent
 ```
 
 ### Python SDK
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -37,21 +37,21 @@ uv add nblm
 ## Quick Example
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 # Initialize client
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create notebook
-notebook = client.create_notebook("My Notebook")
+notebook = client.create_notebook(title="My Notebook")
 
 # Add sources
 client.add_sources(
     notebook_id=notebook.notebook_id,
-    web_sources=[{"url": "https://example.com", "name": "Example"}]
+    web_sources=[WebSource(url="https://example.com", name="Example")]
 )
 
 # Create audio overview
@@ -79,13 +79,13 @@ print(f"Audio status: {audio.status}")
 
 ```python
 from nblm import (
-    GCloudTokenProvider,  # Use gcloud CLI
+    GcloudTokenProvider,  # Use gcloud CLI
     EnvTokenProvider,     # Use environment variable
     NblmClient
 )
 
 # Method 1: gcloud CLI (recommended)
-provider = GCloudTokenProvider()
+provider = GcloudTokenProvider()
 
 # Method 2: Environment variable
 import os
@@ -118,7 +118,7 @@ from nblm import (
 
 # All operations are fully typed
 client: NblmClient
-notebook: Notebook = client.create_notebook("Title")
+notebook: Notebook = client.create_notebook(title="Title")
 sources: BatchCreateSourcesResponse = client.add_sources(...)
 audio: AudioOverviewResponse = client.create_audio_overview(...)
 ```
@@ -129,7 +129,7 @@ audio: AudioOverviewResponse = client.create_audio_overview(...)
 from nblm import NblmClient, NblmError
 
 try:
-    notebook = client.create_notebook("My Notebook")
+    notebook = client.create_notebook(title="My Notebook")
 except NblmError as e:
     print(f"Error: {e}")
 ```

--- a/docs/python/api-reference.md
+++ b/docs/python/api-reference.md
@@ -9,10 +9,10 @@ Complete reference for all classes and methods in the nblm Python SDK.
 Main client class for interacting with the NotebookLM API.
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012",
     location="global",
     endpoint_location="global"
@@ -37,7 +37,7 @@ client = NblmClient(
 Create a new notebook.
 
 ```python
-notebook = client.create_notebook("My Notebook")
+notebook = client.create_notebook(title="My Notebook")
 ```
 
 **`list_recently_viewed(page_size: Optional[int] = None) -> ListRecentlyViewedResponse`**
@@ -134,18 +134,18 @@ client.delete_audio_overview(notebook_id="abc123")
 
 ## Token Providers
 
-### GCloudTokenProvider
+### GcloudTokenProvider
 
 Use gcloud CLI for authentication.
 
 ```python
-from nblm import GCloudTokenProvider
+from nblm import GcloudTokenProvider
 
 # Default (uses 'gcloud' from PATH)
-provider = GCloudTokenProvider()
+provider = GcloudTokenProvider()
 
 # Custom binary path
-provider = GCloudTokenProvider(binary="/usr/local/bin/gcloud")
+provider = GcloudTokenProvider(binary="/usr/local/bin/gcloud")
 ```
 
 #### Constructor Parameters
@@ -355,7 +355,7 @@ Base exception for all nblm errors.
 from nblm import NblmError
 
 try:
-    notebook = client.create_notebook("Test")
+    notebook = client.create_notebook(title="Test")
 except NblmError as e:
     print(f"Error: {e}")
 ```
@@ -382,7 +382,7 @@ from nblm import (
 
 # Type checking with mypy
 def create_and_populate(client: NblmClient, title: str) -> Notebook:
-    notebook: Notebook = client.create_notebook(title)
+    notebook: Notebook = client.create_notebook(title=title)
     response: BatchCreateSourcesResponse = client.add_sources(
         notebook_id=notebook.notebook_id,
         web_sources=[WebSource(url="https://example.com")]

--- a/docs/python/audio.md
+++ b/docs/python/audio.md
@@ -7,10 +7,10 @@ Create and manage audio overviews (podcast-style discussions) for notebooks.
 ### Basic Creation
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, AudioOverviewRequest
+from nblm import NblmClient, GcloudTokenProvider, AudioOverviewRequest
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
@@ -76,18 +76,18 @@ Complete workflow from creating a notebook to generating audio:
 ```python
 from nblm import (
     NblmClient,
-    GCloudTokenProvider,
+    GcloudTokenProvider,
     WebSource,
     AudioOverviewRequest
 )
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # 1. Create notebook
-notebook = client.create_notebook("Tutorial Analysis")
+notebook = client.create_notebook(title="Tutorial Analysis")
 notebook_id = notebook.notebook_id
 
 # 2. Add sources

--- a/docs/python/error-handling.md
+++ b/docs/python/error-handling.md
@@ -9,7 +9,7 @@ from nblm import NblmError
 
 # NblmError is the base exception for all SDK errors
 try:
-    notebook = client.create_notebook("Test")
+    notebook = client.create_notebook(title="Test")
 except NblmError as e:
     print(f"Error: {e}")
 ```
@@ -21,15 +21,15 @@ All errors raised by the SDK are instances of `NblmError`.
 ### Try-Except Pattern
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, NblmError
+from nblm import NblmClient, GcloudTokenProvider, NblmError
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 try:
-    notebook = client.create_notebook("My Notebook")
+    notebook = client.create_notebook(title="My Notebook")
     print(f"Success: {notebook.notebook_id}")
 except NblmError as e:
     print(f"Failed: {e}")
@@ -42,7 +42,7 @@ from nblm import WebSource
 
 try:
     # Create notebook
-    notebook = client.create_notebook("Research")
+    notebook = client.create_notebook(title="Research")
 
     # Add sources
     client.add_sources(
@@ -67,10 +67,10 @@ except NblmError as e:
 ```python
 try:
     client = NblmClient(
-        token_provider=GCloudTokenProvider(),
+        token_provider=GcloudTokenProvider(),
         project_number="123456789012"
     )
-    notebook = client.create_notebook("Test")
+    notebook = client.create_notebook(title="Test")
 
 except NblmError as e:
     error_msg = str(e).lower()
@@ -172,7 +172,7 @@ def retry_with_backoff(
 
 # Usage
 notebook = retry_with_backoff(
-    lambda: client.create_notebook("My Notebook"),
+    lambda: client.create_notebook(title="My Notebook"),
     max_retries=3
 )
 ```
@@ -238,7 +238,7 @@ print(f"Failed: {len(failed)}")
 
 ```python
 import logging
-from nblm import NblmClient, GCloudTokenProvider, NblmError
+from nblm import NblmClient, GcloudTokenProvider, NblmError
 
 # Configure logging
 logging.basicConfig(
@@ -248,13 +248,13 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 try:
     logger.info("Creating notebook...")
-    notebook = client.create_notebook("Test Notebook")
+    notebook = client.create_notebook(title="Test Notebook")
     logger.info(f"Created notebook: {notebook.notebook_id}")
 
 except NblmError as e:
@@ -282,7 +282,7 @@ def log_error(operation: str, error: NblmError, **context):
 
 # Usage
 try:
-    client.create_notebook("Test")
+    client.create_notebook(title="Test")
 except NblmError as e:
     log_error("create_notebook", e, title="Test", project="123456789012")
 ```
@@ -356,17 +356,17 @@ match result:
 ### Automatic Cleanup
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, WebSource
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 notebook = None
 try:
     # Create resources
-    notebook = client.create_notebook("Temporary")
+    notebook = client.create_notebook(title="Temporary")
 
     # Use resources
     client.add_sources(
@@ -446,7 +446,7 @@ client = NblmClient(...)
 from nblm import NblmError
 
 try:
-    client.create_notebook("Test")
+    client.create_notebook(title="Test")
 except NblmError as e:
     print(f"Error type: {type(e)}")
     print(f"Error message: {str(e)}")

--- a/docs/python/notebooks.md
+++ b/docs/python/notebooks.md
@@ -7,20 +7,20 @@ Detailed guide for notebook operations in the Python SDK.
 ### Basic Creation
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
-notebook = client.create_notebook("My Research Notebook")
+notebook = client.create_notebook(title="My Research Notebook")
 ```
 
 ### Accessing Notebook Information
 
 ```python
-notebook = client.create_notebook("Test Notebook")
+notebook = client.create_notebook(title="Test Notebook")
 
 print(f"Title: {notebook.title}")
 print(f"Notebook ID: {notebook.notebook_id}")
@@ -35,7 +35,7 @@ print(f"Updated: {notebook.update_time}")
 from nblm import NblmError
 
 try:
-    notebook = client.create_notebook("My Notebook")
+    notebook = client.create_notebook(title="My Notebook")
 except NblmError as e:
     print(f"Failed to create notebook: {e}")
 ```
@@ -108,7 +108,7 @@ response = client.delete_notebooks(notebook_names)
 
 ```python
 # Create a notebook
-notebook = client.create_notebook("Temporary Notebook")
+notebook = client.create_notebook(title="Temporary Notebook")
 
 # Use the full name for deletion
 client.delete_notebooks([notebook.name])
@@ -126,15 +126,15 @@ client.delete_notebooks([notebook.name])
 ### Create, Use, and Clean Up
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, WebSource
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create notebook
-notebook = client.create_notebook("Temporary Analysis")
+notebook = client.create_notebook(title="Temporary Analysis")
 notebook_id = notebook.notebook_id
 
 try:
@@ -172,7 +172,7 @@ titles = ["Project A", "Project B", "Project C"]
 created_notebooks = []
 
 for title in titles:
-    notebook = client.create_notebook(title)
+    notebook = client.create_notebook(title=title)
     created_notebooks.append(notebook)
     print(f"Created: {notebook.notebook_id}")
 ```
@@ -208,7 +208,7 @@ if old_notebooks:
 from nblm import NblmError
 
 try:
-    notebook = client.create_notebook("Test")
+    notebook = client.create_notebook(title="Test")
 except NblmError as e:
     if "authentication" in str(e).lower():
         print("Authentication failed. Check your credentials.")
@@ -241,7 +241,7 @@ except NblmError as e:
 
 ```python
 # Save for later use
-notebook = client.create_notebook("Important Notebook")
+notebook = client.create_notebook(title="Important Notebook")
 
 # Store the ID
 notebook_id = notebook.notebook_id
@@ -267,7 +267,7 @@ def create_notebook_safely(client: NblmClient, title: str) -> Optional[Notebook]
         return None
 
     try:
-        return client.create_notebook(title)
+        return client.create_notebook(title=title)
     except NblmError as e:
         print(f"Failed to create notebook: {e}")
         return None
@@ -285,7 +285,7 @@ def temporary_notebook(
     title: str
 ) -> Generator[Notebook, None, None]:
     """Create a notebook and automatically delete it when done."""
-    notebook = client.create_notebook(title)
+    notebook = client.create_notebook(title=title)
     try:
         yield notebook
     finally:

--- a/docs/python/quickstart.md
+++ b/docs/python/quickstart.md
@@ -33,16 +33,16 @@ Example output: `123456789012`
 ### 3. Create your first notebook
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 # Initialize client
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create a notebook
-notebook = client.create_notebook("My First Notebook")
+notebook = client.create_notebook(title="My First Notebook")
 print(f"Created: {notebook.title}")
 print(f"Notebook ID: {notebook.notebook_id}")
 ```
@@ -54,7 +54,7 @@ Here's a complete workflow from creating a notebook to generating an audio overv
 ```python
 from nblm import (
     NblmClient,
-    GCloudTokenProvider,
+    GcloudTokenProvider,
     WebSource,
     TextSource,
     AudioOverviewRequest
@@ -62,12 +62,12 @@ from nblm import (
 
 # 1. Initialize client
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # 2. Create a notebook
-notebook = client.create_notebook("Python Tutorial Notebook")
+notebook = client.create_notebook(title="Python Tutorial Notebook")
 notebook_id = notebook.notebook_id
 print(f"Created notebook: {notebook_id}")
 
@@ -108,10 +108,10 @@ print(f"Total notebooks: {len(notebooks.notebooks)}")
 ### Option 1: gcloud CLI (Recommended)
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 ```
@@ -134,10 +134,10 @@ client = NblmClient(
 ### Option 3: Custom gcloud Binary Path
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(binary="/custom/path/gcloud"),
+    token_provider=GcloudTokenProvider(binary="/custom/path/gcloud"),
     project_number="123456789012"
 )
 ```
@@ -147,15 +147,15 @@ client = NblmClient(
 ### Create and populate a notebook
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, WebSource
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create
-notebook = client.create_notebook("Research Notebook")
+notebook = client.create_notebook(title="Research Notebook")
 
 # Add multiple web sources
 urls = [
@@ -173,15 +173,15 @@ client.add_sources(
 ### Error handling
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, NblmError
+from nblm import NblmClient, GcloudTokenProvider, NblmError
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 try:
-    notebook = client.create_notebook("Test Notebook")
+    notebook = client.create_notebook(title="Test Notebook")
     print(f"Success: {notebook.notebook_id}")
 except NblmError as e:
     print(f"Failed: {e}")
@@ -193,7 +193,7 @@ except NblmError as e:
 
 ```python
 import os
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 # Set once
 os.environ["NBLM_PROJECT_NUMBER"] = "123456789012"
@@ -202,7 +202,7 @@ os.environ["NBLM_ENDPOINT_LOCATION"] = "global"
 
 # Create client (will use environment variables)
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number=os.environ["NBLM_PROJECT_NUMBER"]
 )
 ```
@@ -210,11 +210,11 @@ client = NblmClient(
 ### Custom locations
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider
+from nblm import NblmClient, GcloudTokenProvider
 
 # Use US location (for compliance requirements)
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012",
     location="us",
     endpoint_location="us"

--- a/docs/python/sources.md
+++ b/docs/python/sources.md
@@ -7,10 +7,10 @@ Detailed guide for managing sources in notebooks with the Python SDK.
 ### Add Web Sources
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, WebSource
+from nblm import NblmClient, GcloudTokenProvider, WebSource
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
@@ -294,15 +294,15 @@ client.delete_sources(
 ### Create Notebook and Add Sources
 
 ```python
-from nblm import NblmClient, GCloudTokenProvider, WebSource, TextSource
+from nblm import NblmClient, GcloudTokenProvider, WebSource, TextSource
 
 client = NblmClient(
-    token_provider=GCloudTokenProvider(),
+    token_provider=GcloudTokenProvider(),
     project_number="123456789012"
 )
 
 # Create notebook
-notebook = client.create_notebook("Research: Python Best Practices")
+notebook = client.create_notebook(title="Research: Python Best Practices")
 
 # Add initial sources
 client.add_sources(


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this pull request changes and why. -->

Updated various documentation files to streamline CLI command usage by removing the `--auth gcloud` flag. This change enhances clarity and simplifies user interactions with the NotebookLM API. Adjustments were made across README, CLI, and Python SDK documentation to reflect this update.


## Testing

- [ ] `makers all`
- [ ] `makers py-all`

<!-- List any additional manual checks or scripts you ran. -->

## Additional Context

<!-- Optional: screenshots, linked issues, follow-up tasks, etc. -->
