### PR TITLE
feat: implement doctor command in CLI for environment diagnostics

### DIFF
--- a/crates/nblm-cli/src/app.rs
+++ b/crates/nblm-cli/src/app.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 use nblm_core::{NblmClient, RetryConfig};
 
 use crate::args::{Cli, Command};
-use crate::ops::{audio, notebooks, share, sources};
+use crate::ops::{audio, doctor, notebooks, share, sources};
 use crate::util::auth::build_token_provider;
 
 pub struct NblmApp {
@@ -59,6 +59,7 @@ impl NblmApp {
             Command::Sources(cmd) => sources::run(cmd, &self.client, json_mode).await,
             Command::Audio(cmd) => audio::run(cmd, &self.client, json_mode).await,
             Command::Share(cmd) => share::run(cmd, &self.client, json_mode).await,
+            Command::Doctor(cmd) => doctor::run(cmd).await,
         }
     }
 }

--- a/crates/nblm-cli/src/args.rs
+++ b/crates/nblm-cli/src/args.rs
@@ -66,6 +66,7 @@ pub enum Command {
     Audio(ops::audio::Command),
     #[command(subcommand)]
     Share(ops::share::Command),
+    Doctor(ops::doctor::DoctorArgs),
 }
 
 #[derive(Copy, Clone, ValueEnum)]

--- a/crates/nblm-cli/tests/_helpers/cmd.rs
+++ b/crates/nblm-cli/tests/_helpers/cmd.rs
@@ -42,6 +42,9 @@ impl CommonArgs {
         ]);
     }
 
+    // Some integration tests reuse this helper while others do not; keep the helper available
+    // without tripping per-test dead_code lints.
+    #[allow(dead_code)]
     pub fn with_base_url(&self, cmd: &mut Command, base_url: &str) {
         self.apply(cmd);
         cmd.args(["--base-url", base_url]);

--- a/crates/nblm-cli/tests/doctor.rs
+++ b/crates/nblm-cli/tests/doctor.rs
@@ -1,0 +1,139 @@
+mod _helpers;
+
+use predicates::prelude::*;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn doctor_all_env_vars_present() {
+    let mut cmd = _helpers::cmd::nblm();
+    let common = _helpers::cmd::CommonArgs::default();
+    common.apply(&mut cmd);
+    cmd.env("NBLM_PROJECT_NUMBER", "224840249322");
+    cmd.env("NBLM_ENDPOINT_LOCATION", "us-central1");
+    cmd.env("NBLM_LOCATION", "global");
+    cmd.arg("doctor");
+
+    let assert = cmd.assert();
+    assert
+        .code(0)
+        .stdout(predicate::str::contains(
+            "Running NotebookLM environment diagnostics",
+        ))
+        .stdout(predicate::str::contains(
+            "[ok] NBLM_PROJECT_NUMBER=224840249322",
+        ))
+        .stdout(predicate::str::contains(
+            "[ok] NBLM_ENDPOINT_LOCATION=us-central1",
+        ))
+        .stdout(predicate::str::contains("[ok] NBLM_LOCATION=global"))
+        .stdout(predicate::str::contains("Summary: All 3 checks passed"))
+        .stdout(predicate::str::contains(
+            "All critical checks passed. You're ready to use nblm",
+        ));
+}
+
+#[test]
+#[serial]
+fn doctor_missing_required_env_var() {
+    let mut cmd = _helpers::cmd::nblm();
+    let common = _helpers::cmd::CommonArgs::default();
+    common.apply(&mut cmd);
+    cmd.env_remove("NBLM_PROJECT_NUMBER");
+    cmd.env("NBLM_ENDPOINT_LOCATION", "us-central1");
+    cmd.env("NBLM_LOCATION", "global");
+    cmd.arg("doctor");
+
+    let assert = cmd.assert();
+    assert
+        .code(2) // Error exit code
+        .stdout(predicate::str::contains(
+            "[error] NBLM_PROJECT_NUMBER missing",
+        ))
+        .stdout(predicate::str::contains(
+            "Suggestion: export NBLM_PROJECT_NUMBER=<your-project-number>",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 1 checks failing out of 3",
+        ));
+}
+
+#[test]
+#[serial]
+fn doctor_missing_optional_env_vars() {
+    let mut cmd = _helpers::cmd::nblm();
+    let common = _helpers::cmd::CommonArgs::default();
+    common.apply(&mut cmd);
+    cmd.env("NBLM_PROJECT_NUMBER", "224840249322");
+    cmd.env_remove("NBLM_ENDPOINT_LOCATION");
+    cmd.env_remove("NBLM_LOCATION");
+    cmd.arg("doctor");
+
+    let assert = cmd.assert();
+    assert
+        .code(1) // Warning exit code
+        .stdout(predicate::str::contains(
+            "[ok] NBLM_PROJECT_NUMBER=224840249322",
+        ))
+        .stdout(predicate::str::contains(
+            "[warn] NBLM_ENDPOINT_LOCATION missing",
+        ))
+        .stdout(predicate::str::contains(
+            "Suggestion: export NBLM_ENDPOINT_LOCATION=us-central1",
+        ))
+        .stdout(predicate::str::contains("[warn] NBLM_LOCATION missing"))
+        .stdout(predicate::str::contains(
+            "Suggestion: export NBLM_LOCATION=us-central1",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 2 checks failing out of 3",
+        ));
+}
+
+#[test]
+#[serial]
+fn doctor_all_env_vars_missing() {
+    let mut cmd = _helpers::cmd::nblm();
+    let common = _helpers::cmd::CommonArgs::default();
+    common.apply(&mut cmd);
+    cmd.env_remove("NBLM_PROJECT_NUMBER");
+    cmd.env_remove("NBLM_ENDPOINT_LOCATION");
+    cmd.env_remove("NBLM_LOCATION");
+    cmd.arg("doctor");
+
+    let assert = cmd.assert();
+    assert
+        .code(2) // Error exit code (highest priority)
+        .stdout(predicate::str::contains(
+            "[error] NBLM_PROJECT_NUMBER missing",
+        ))
+        .stdout(predicate::str::contains(
+            "[warn] NBLM_ENDPOINT_LOCATION missing",
+        ))
+        .stdout(predicate::str::contains("[warn] NBLM_LOCATION missing"))
+        .stdout(predicate::str::contains(
+            "Summary: 3 checks failing out of 3",
+        ));
+}
+
+#[test]
+#[serial]
+fn doctor_empty_env_var_treated_as_missing() {
+    let mut cmd = _helpers::cmd::nblm();
+    let common = _helpers::cmd::CommonArgs::default();
+    common.apply(&mut cmd);
+    cmd.env("NBLM_PROJECT_NUMBER", ""); // Empty string should be treated as missing
+    cmd.env("NBLM_ENDPOINT_LOCATION", "us-central1");
+    cmd.env("NBLM_LOCATION", "global");
+    cmd.arg("doctor");
+
+    let assert = cmd.assert();
+    assert
+        .code(2) // Error exit code
+        .stdout(predicate::str::contains(
+            "[error] NBLM_PROJECT_NUMBER missing",
+        ))
+        .stdout(predicate::str::contains(
+            "Suggestion: export NBLM_PROJECT_NUMBER=<your-project-number>",
+        ));
+}


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this pull request changes and why. -->

- Added the `doctor` command to the CLI, allowing users to run environment diagnostics.
- Updated command handling to include the new `Doctor` subcommand.
- Introduced tests for the `doctor` command to validate environment variable checks, including scenarios for missing required and optional variables.
- Enhanced the command's output to provide clear feedback on the status of environment variables.


## Testing

- [x] `makers all`
- [x] `makers py-all`

<!-- List any additional manual checks or scripts you ran. -->

## Additional Context

<!-- Optional: screenshots, linked issues, follow-up tasks, etc. -->

Ref https://github.com/K-dash/nblm-rs/issues/61
