### PR TITLE
refactor: align output markers in doctor command tests

### DIFF
--- a/crates/nblm-cli/tests/doctor.rs
+++ b/crates/nblm-cli/tests/doctor.rs
@@ -21,12 +21,12 @@ fn doctor_all_env_vars_present() {
             "Running NotebookLM environment diagnostics",
         ))
         .stdout(predicate::str::contains(
-            "[ok] NBLM_PROJECT_NUMBER=224840249322",
+            "   [ok] NBLM_PROJECT_NUMBER=224840249322",
         ))
         .stdout(predicate::str::contains(
-            "[ok] NBLM_ENDPOINT_LOCATION=us-central1",
+            "   [ok] NBLM_ENDPOINT_LOCATION=us-central1",
         ))
-        .stdout(predicate::str::contains("[ok] NBLM_LOCATION=global"))
+        .stdout(predicate::str::contains("   [ok] NBLM_LOCATION=global"))
         .stdout(predicate::str::contains("Summary: All 3 checks passed"))
         .stdout(predicate::str::contains(
             "All critical checks passed. You're ready to use nblm",
@@ -73,15 +73,15 @@ fn doctor_missing_optional_env_vars() {
     assert
         .code(1) // Warning exit code
         .stdout(predicate::str::contains(
-            "[ok] NBLM_PROJECT_NUMBER=224840249322",
+            "   [ok] NBLM_PROJECT_NUMBER=224840249322",
         ))
         .stdout(predicate::str::contains(
-            "[warn] NBLM_ENDPOINT_LOCATION missing",
+            " [warn] NBLM_ENDPOINT_LOCATION missing",
         ))
         .stdout(predicate::str::contains(
             "Suggestion: export NBLM_ENDPOINT_LOCATION=us-central1",
         ))
-        .stdout(predicate::str::contains("[warn] NBLM_LOCATION missing"))
+        .stdout(predicate::str::contains(" [warn] NBLM_LOCATION missing"))
         .stdout(predicate::str::contains(
             "Suggestion: export NBLM_LOCATION=us-central1",
         ))
@@ -108,9 +108,9 @@ fn doctor_all_env_vars_missing() {
             "[error] NBLM_PROJECT_NUMBER missing",
         ))
         .stdout(predicate::str::contains(
-            "[warn] NBLM_ENDPOINT_LOCATION missing",
+            " [warn] NBLM_ENDPOINT_LOCATION missing",
         ))
-        .stdout(predicate::str::contains("[warn] NBLM_LOCATION missing"))
+        .stdout(predicate::str::contains(" [warn] NBLM_LOCATION missing"))
         .stdout(predicate::str::contains(
             "Summary: 3 checks failing out of 3",
         ));

--- a/crates/nblm-core/src/doctor/checks.rs
+++ b/crates/nblm-core/src/doctor/checks.rs
@@ -9,15 +9,6 @@ pub enum CheckStatus {
 }
 
 impl CheckStatus {
-    /// Convert status to ASCII marker
-    pub fn as_marker(&self) -> &'static str {
-        match self {
-            CheckStatus::Pass => "[ok]",
-            CheckStatus::Warning => "[warn]",
-            CheckStatus::Error => "[error]",
-        }
-    }
-
     /// Convert status to exit code contribution
     pub fn exit_code(&self) -> i32 {
         match self {
@@ -25,6 +16,17 @@ impl CheckStatus {
             CheckStatus::Warning => 1,
             CheckStatus::Error => 2,
         }
+    }
+
+    /// Convert status to ASCII marker with aligned label
+    pub fn as_marker(&self) -> String {
+        let label = match self {
+            CheckStatus::Pass => "ok",
+            CheckStatus::Warning => "warn",
+            CheckStatus::Error => "error",
+        };
+        let total_width = "error".len() + 2; // include brackets
+        format!("{:>width$}", format!("[{}]", label), width = total_width)
     }
 }
 
@@ -173,8 +175,8 @@ mod tests {
 
     #[test]
     fn test_check_status_markers() {
-        assert_eq!(CheckStatus::Pass.as_marker(), "[ok]");
-        assert_eq!(CheckStatus::Warning.as_marker(), "[warn]");
+        assert_eq!(CheckStatus::Pass.as_marker(), "   [ok]");
+        assert_eq!(CheckStatus::Warning.as_marker(), " [warn]");
         assert_eq!(CheckStatus::Error.as_marker(), "[error]");
     }
 
@@ -188,7 +190,7 @@ mod tests {
     #[test]
     fn test_check_result_format() {
         let result = CheckResult::new("test", CheckStatus::Pass, "Test passed");
-        assert_eq!(result.format(), "[ok] Test passed");
+        assert_eq!(result.format(), "   [ok] Test passed");
 
         let result_with_suggestion = CheckResult::new("test", CheckStatus::Warning, "Test warning")
             .with_suggestion("Try this fix");


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this pull request changes and why. -->

- Updated the output format of the doctor command tests to align the status markers with leading spaces for improved readability.
- Modified the `as_marker` method in `CheckStatus` to generate aligned markers dynamically.
- Adjusted related tests to reflect the new output format, ensuring consistency across the diagnostic checks.

## Testing

- [x] `makers all`
- [x] `makers py-all`

<!-- List any additional manual checks or scripts you ran. -->

## Additional Context

<!-- Optional: screenshots, linked issues, follow-up tasks, etc. -->

Ref https://github.com/K-dash/nblm-rs/issues/61
